### PR TITLE
fixes #9 ( Sqlite storage makes asp.net core application very slow )

### DIFF
--- a/Hangfire.SQLite/SQLiteStorageConnection.cs
+++ b/Hangfire.SQLite/SQLiteStorageConnection.cs
@@ -212,7 +212,7 @@ where j.Id = @jobId", _storage.GetSchemaName());
                 else
                 {
                     // update
-                    connection.Execute(string.Format(@"update {0} set Name = @name, Value = @value where JobId = @jobId;", tableName),
+                    connection.Execute(string.Format(@"update {0} set Value = @value where JobId = @jobId and Name = @name;", tableName),
                     new { jobId = jobId, name, value });
                 }
             }, true);


### PR DESCRIPTION
The first commit switches from `ReaderWriterLock` to `ReaderWriterLockSlim`.

The second one tries to release db write lock (see `SQLiteJobQueue.Dequeue` method) as soon as possible. This allows us to write to the database (for example enqueue new jobs) without waiting for `QueuePollInterval` timespan.