### PR TITLE
Fix work item executed multiple times issue

### DIFF
--- a/src/Hangfire.SQLite/Hangfire.SQLite.csproj
+++ b/src/Hangfire.SQLite/Hangfire.SQLite.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>

--- a/src/Hangfire.SQLite/Install.sql
+++ b/src/Hangfire.SQLite/Install.sql
@@ -56,12 +56,12 @@ CREATE TABLE IF NOT EXISTS [$(HangFireSchema).JobQueue] (
         [Id]    INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
         [JobId] integer NOT NULL,
         [Queue] nvarchar(50) NOT NULL COLLATE NOCASE,
-        [FetchedAt]     datetime
-
+		[Status]	varchar(1) NOT NULL,
+        [FetchedAt]	datetime
 );
 CREATE INDEX IF NOT EXISTS [JobQueue_IX_HangFire_JobQueue_QueueAndFetchedAt]
 ON [$(HangFireSchema).JobQueue]
-([Queue] DESC, [FetchedAt] DESC);
+([Queue] DESC, [Status] DESC, [FetchedAt] DESC);
 
 CREATE TABLE IF NOT EXISTS [$(HangFireSchema).Server] (
         [Id]    nvarchar(100) PRIMARY KEY NOT NULL COLLATE NOCASE,

--- a/src/Hangfire.SQLite/SQLiteStorageOptions.cs
+++ b/src/Hangfire.SQLite/SQLiteStorageOptions.cs
@@ -67,6 +67,23 @@ namespace Hangfire.SQLite
         [Obsolete("Does not make sense anymore. Background jobs re-queued instantly even after ungraceful shutdown now. Will be removed in 2.0.0.")]
         public TimeSpan InvisibilityTimeout { get; set; }
 
+        TimeSpan _slidingInvisibilityTimeout = TimeSpan.FromSeconds(5);
+
+        public TimeSpan SlidingInvisibilityTimeout
+        {
+            get { return _slidingInvisibilityTimeout; }
+            set
+            {
+                if (value <= TimeSpan.Zero)
+                {
+                    throw new ArgumentOutOfRangeException("Sliding timeout should be greater than zero");
+                }
+
+                _slidingInvisibilityTimeout = value;
+            }
+        }
+
+
         public bool PrepareSchemaIfNecessary { get; set; }
 
         public TimeSpan JobExpirationCheckInterval { get; set; }

--- a/src/Hangfire.SQLite/SQLiteStorageOptions.cs
+++ b/src/Hangfire.SQLite/SQLiteStorageOptions.cs
@@ -40,6 +40,7 @@ namespace Hangfire.SQLite
             DashboardJobListLimit = 10000;
             _schemaName = Constants.DefaultSchema;
             TransactionTimeout = TimeSpan.FromMinutes(1);
+            JobQueueExecutionTimeout = TimeSpan.FromMinutes(60);
         }
 
         public IsolationLevel? TransactionIsolationLevel { get; set; }
@@ -82,6 +83,14 @@ namespace Hangfire.SQLite
                 _slidingInvisibilityTimeout = value;
             }
         }
+
+        /// <summary>
+        /// Timeout for execution of job in JobQueue, default 60 mins.
+        /// If job didn't finish before timeout, the job will be dequeued and executed again.
+        /// Increase the value if you have long-run jobs, 
+        /// decrease the value if you want to retry the failed jobs sooner.
+        /// </summary>
+        public TimeSpan JobQueueExecutionTimeout { get; set; }
 
 
         public bool PrepareSchemaIfNecessary { get; set; }


### PR DESCRIPTION
SQLiteJobQueue.Dequeue() used 
``where (FetchedAt is null or FetchedAt < @fetchedAt)
``
instead of 
``where (FetchedAt is null or FetchedAt < DATEADD(second, @timeout, GETUTCDATE()))
``
and this causes work item is fetched by every worker and executed multiple times.

Referring to Hangfire.SqlServer [1.6.14](https://github.com/HangfireIO/Hangfire/releases/tag/v1.6.14), I add SlidingInvisibilityTimeout option (5 seconds by default) and use it to simulate  DATEADD(second, ``@timeout``, GETUTCDATE())),  I believe this can fix the duplicated executions issue.




