### PR TITLE
Improve connection string handling

### DIFF
--- a/src/Hangfire.SQLite/Hangfire.SQLite.csproj
+++ b/src/Hangfire.SQLite/Hangfire.SQLite.csproj
@@ -31,13 +31,11 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.105.2" />      
-    <Reference Include="System.Configuration" />
     <Reference Include="System.Transactions" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="2.0.0" />      
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />     
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">

--- a/src/Hangfire.SQLite/SQLiteStorage.cs
+++ b/src/Hangfire.SQLite/SQLiteStorage.cs
@@ -19,7 +19,6 @@ using Hangfire.Server;
 using Hangfire.Storage;
 using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
@@ -50,24 +49,19 @@ namespace Hangfire.SQLite
         }
 
         /// <summary>
-        /// Initializes SqlServerStorage from the provided SQLiteStorageOptions and either the provided connection
-        /// string or the connection string with provided name pulled from the application config file.       
+        /// Initializes SQLiteStorage from the provided SQLiteStorageOptions and the provided connection string.
         /// </summary>
-        /// <param name="nameOrConnectionString">Either a SQL Server connection string or the name of 
-        /// a SQL Server connection string located in the connectionStrings node in the application config</param>
+        /// <param name="connectionString">A SQLite connection string</param>
         /// <param name="options"></param>
-        /// <exception cref="ArgumentNullException"><paramref name="nameOrConnectionString"/> argument is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connectionString"/> argument is null.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="options"/> argument is null.</exception>
-        /// <exception cref="ArgumentException"><paramref name="nameOrConnectionString"/> argument is neither 
-        /// a valid SQL Server connection string nor the name of a connection string in the application
-        /// config file.</exception>
-        public SQLiteStorage(string nameOrConnectionString, SQLiteStorageOptions options)
+        public SQLiteStorage(string connectionString, SQLiteStorageOptions options)
         {
-            if (string.IsNullOrEmpty(nameOrConnectionString)) throw new ArgumentNullException(nameof(nameOrConnectionString));
+            if (string.IsNullOrEmpty(connectionString)) throw new ArgumentNullException(nameof(connectionString));
             if (options == null) throw new ArgumentNullException(nameof(options));
 
-            _connectionString = GetConnectionString(nameOrConnectionString);
-            _options = options;            
+            _connectionString = connectionString;
+            _options = options;
 
             if (!_dbMonitorCache.ContainsKey(_connectionString))
             {
@@ -285,34 +279,6 @@ namespace Hangfire.SQLite
         {
             var defaultQueueProvider = new SQLiteJobQueueProvider(this, _options);
             QueueProviders = new PersistentJobQueueProviderCollection(defaultQueueProvider);
-        }
-
-        private string GetConnectionString(string nameOrConnectionString)
-        {
-            if (IsConnectionString(nameOrConnectionString))
-            {
-                return nameOrConnectionString;
-            }
-
-            if (IsConnectionStringInConfiguration(nameOrConnectionString))
-            {
-                return ConfigurationManager.ConnectionStrings[nameOrConnectionString].ConnectionString;
-            }
-
-            throw new ArgumentException(
-                $"Could not find connection string with name '{nameOrConnectionString}' in application config file");
-        }
-
-        private bool IsConnectionString(string nameOrConnectionString)
-        {
-            return nameOrConnectionString.Contains(";");
-        }
-
-        private bool IsConnectionStringInConfiguration(string connectionStringName)
-        {
-            var connectionStringSetting = ConfigurationManager.ConnectionStrings[connectionStringName];
-
-            return connectionStringSetting != null;
         }
 
 #if !NETSTANDARD        

--- a/src/Hangfire.SQLite/SQLiteStorage.cs
+++ b/src/Hangfire.SQLite/SQLiteStorage.cs
@@ -121,34 +121,12 @@ namespace Hangfire.SQLite
 
         public override string ToString()
         {
-            const string canNotParseMessage = "<Connection string can not be parsed>";
-
-            try
-            {
-                var parts = _connectionString.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
-                    .Select(x => x.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries))
-                    .Select(x => new { Key = x[0].Trim(), Value = x[1].Trim() })
-                    .ToDictionary(x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase);
-                                
-                var builder = new StringBuilder();
-
-                foreach (var alias in new[] { "Data Source", "Server", "Address" })
-                {
-                    if (parts.ContainsKey(alias))
-                    {
-                        builder.Append(parts[alias]);
-                        break;
-                    }
-                }
-
-                return builder.Length != 0
-                    ? $"SQLite Server: {builder}"
-                    : canNotParseMessage;
-            }
-            catch (Exception)
-            {
-                return canNotParseMessage;
-            }
+#if NETSTANDARD
+            var connectionStringBuilder = new SqliteConnectionStringBuilder(_connectionString);
+#else
+            var connectionStringBuilder = new SQLiteConnectionStringBuilder(_connectionString);
+#endif
+            return $"SQLite: {connectionStringBuilder.DataSource}";
         }
 
         internal void UseConnection([InstantHandle] Action<DbConnection> action, bool isWriteLock = false)

--- a/src/Hangfire.SQLite/SQLiteStorage.cs
+++ b/src/Hangfire.SQLite/SQLiteStorage.cs
@@ -235,7 +235,7 @@ namespace Hangfire.SQLite
             var connection = new SqliteConnection(_connectionString);
 #else
             var connection = new SQLiteConnection(_connectionString)
-            {   //SQLite只支持IsolationLevel.Serializable和IsolationLevel.ReadCommitted, 设置其它IsolationLevel自动转换为这两种之一
+            {
                 Flags = SQLiteConnectionFlags.MapIsolationLevels
             };
 #endif

--- a/src/Hangfire.SQLite/SQLiteStorage.cs
+++ b/src/Hangfire.SQLite/SQLiteStorage.cs
@@ -21,8 +21,6 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Linq;
-using System.Text;
 using System.Threading;
 
 #if NETSTANDARD


### PR DESCRIPTION
Accept connection string only as parameter to SQLiteStorage constructor

By requiring an explicit connection string, there is no guessing involved, this fixes #18.

Also, getting the connection string from a configuration file in .NET Core is unlikely to be from an `App.config` file through `System.Configuration.ConfigurationManager`. It is more likely to be from an `appsettings.json ` file using code following the [JSON Configuration](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?tabs=basicconfiguration#json-configuration) idiom of .NET Core:

```csharp
IConfigurationBuilder builder = new ConfigurationBuilder()
    .SetBasePath(Directory.GetCurrentDirectory())
    .AddJsonFile("appsettings.json");
IConfiguration configuration = builder.Build();
string hangfireConnectionString = configuration.GetConnectionString("Hangfire");
```

This also greatly simplifies the implementation and removes the dependency on `System.Configuration`.

Also simplify connection string parsing by using SqliteConnectionStringBuilder/SQLiteConnectionStringBuilder